### PR TITLE
Add monitoring mode (do not intercept requests flagged as coming from…

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Datadome.configure do |config|
 
   # Add exclude matchers (optional)
   config.exclude_matchers << ->(host, path) { path =~ /\.(jpg|jpeg|png|gif)/i }
+  
+  # Enable monitoring mode (optional)
+  # Does not block incoming requests flagged as coming from a bot (useful for logging/monitoring)
+  config.monitoring_mode = true
 end
 
 Datadome.logger = Logger.new(STDOUT, level: :debug)

--- a/lib/datadome/configuration.rb
+++ b/lib/datadome/configuration.rb
@@ -9,9 +9,10 @@ module Datadome
       @api_server = "api.datadome.co"
       @exclude_matchers = []
       @include_matchers = []
+      @monitoring_mode = false
     end
 
-    attr_accessor :api_key, :api_server, :exclude_matchers, :include_matchers
+    attr_accessor :api_key, :api_server, :exclude_matchers, :include_matchers, :monitoring_mode
 
   end
 end

--- a/lib/datadome/inquirer.rb
+++ b/lib/datadome/inquirer.rb
@@ -5,9 +5,10 @@ require "rack"
 module Datadome
   class Inquirer
 
-    def initialize(env, exclude_matchers: nil, include_matchers: nil)
+    def initialize(env, exclude_matchers: nil, include_matchers: nil, monitoring_mode: false)
       @env = env
 
+      @monitoring_mode = monitoring_mode
       @exclude_matchers = exclude_matchers || Datadome.configuration.exclude_matchers
       @include_matchers = include_matchers || Datadome.configuration.include_matchers
     end
@@ -60,7 +61,7 @@ module Datadome
     end
 
     def intercept?
-      @validation_response.pass == false || @validation_response.redirect
+      @monitoring_mode == false && (@validation_response.pass == false || @validation_response.redirect)
     end
 
     def inquire

--- a/spec/datadome/inquirer_spec.rb
+++ b/spec/datadome/inquirer_spec.rb
@@ -3,54 +3,55 @@
 require "spec_helper"
 
 RSpec.describe Datadome::Inquirer do
+  let(:env) do
+    {
+      "SERVER_SOFTWARE" => "thin 1.7.2 codename Bachmanity",
+      "SERVER_NAME" => "www.my-domain.com",
+      "rack.input" => StringIO.new("the body"),
+      "rack.version" => [1, 0],
+      # "rack.errors"=>#<IO:<STDERR>>,
+      "rack.multithread" => false,
+      "rack.multiprocess" => false,
+      "rack.run_once" => false,
+      "REQUEST_METHOD" => "GET",
+      "REQUEST_PATH" => "/my/path",
+      "PATH_INFO" => "/my/path",
+      "QUERY_STRING" => "foo=bar&baz=1",
+      "REQUEST_URI" => "/my/path?foo=bar&baz=1",
+      "HTTP_VERSION" => "HTTP/1.1",
+      "HTTP_HOST" => "www.my-domain.com",
+      "HTTP_CONNECTION" => "keep-alive",
+      "HTTP_PRAGMA" => "no-cache",
+      "HTTP_CACHE_CONTROL" => "no-cache, no-store, must-revalidate",
+      "HTTP_ACCEPT" => "*/*",
+      "HTTP_X_CSRF_TOKEN" => "p8NNwjcp0NBxO7hf5Y4jj10alFvIuE6qCHxGbz4tvNI3FHjZMutWhOJodqgneFKt9cSs1pRNq6Tbe7t1MqqYmA==",
+      "HTTP_USER_AGENT" => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36",
+      "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest",
+      "HTTP_X_FORWARDED_FOR" => "12.23.34.45",
+      "HTTP_ORIGIN" => "www.my-origin-domain.com",
+      "HTTP_REFERER" => "http://www.other-domain.com/other/path",
+      "HTTP_ACCEPT_CHARSET" => "utf-8, iso-8859-1;q=0.5",
+      "HTTP_ACCEPT_ENCODING" => "gzip, deflate",
+      "HTTP_ACCEPT_LANGUAGE" => "fr-FR,fr;q=0.8,en-US;q=0.6,en;q=0.4",
+      "HTTP_COOKIE" => "foo=bar; datadome=AHrlqAAAAAMA9RBP7xmrgZcAAAAAAA%3D%3D; baz=bar",
+      "GATEWAY_INTERFACE" => "CGI/1.2",
+      "SERVER_PORT" => "80",
+      "SERVER_PROTOCOL" => "HTTP/1.1",
+      "rack.url_scheme" => "http",
+      "SCRIPT_NAME" => "",
+      "REMOTE_ADDR" => "192.168.1.1",
+      "ORIGINAL_FULLPATH" => "/my/path?foo=bar&baz=1",
+      "ORIGINAL_SCRIPT_NAME" => "",
+    }
+  end
+
+  let(:exclude_matchers) { [] }
+  let(:include_matchers) { [] }
+  let(:monitoring_mode) { false }
+
+  subject { described_class.new(env, exclude_matchers: exclude_matchers, include_matchers: include_matchers, monitoring_mode: monitoring_mode) }
+
   describe "#ignore?" do
-    let(:env) do
-      {
-        "SERVER_SOFTWARE" => "thin 1.7.2 codename Bachmanity",
-        "SERVER_NAME" => "www.my-domain.com",
-        "rack.input" => StringIO.new("the body"),
-        "rack.version" => [1, 0],
-        # "rack.errors"=>#<IO:<STDERR>>,
-        "rack.multithread" => false,
-        "rack.multiprocess" => false,
-        "rack.run_once" => false,
-        "REQUEST_METHOD" => "GET",
-        "REQUEST_PATH" => "/my/path",
-        "PATH_INFO" => "/my/path",
-        "QUERY_STRING" => "foo=bar&baz=1",
-        "REQUEST_URI" => "/my/path?foo=bar&baz=1",
-        "HTTP_VERSION" => "HTTP/1.1",
-        "HTTP_HOST" => "www.my-domain.com",
-        "HTTP_CONNECTION" => "keep-alive",
-        "HTTP_PRAGMA" => "no-cache",
-        "HTTP_CACHE_CONTROL" => "no-cache, no-store, must-revalidate",
-        "HTTP_ACCEPT" => "*/*",
-        "HTTP_X_CSRF_TOKEN" => "p8NNwjcp0NBxO7hf5Y4jj10alFvIuE6qCHxGbz4tvNI3FHjZMutWhOJodqgneFKt9cSs1pRNq6Tbe7t1MqqYmA==",
-        "HTTP_USER_AGENT" => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36",
-        "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest",
-        "HTTP_X_FORWARDED_FOR" => "12.23.34.45",
-        "HTTP_ORIGIN" => "www.my-origin-domain.com",
-        "HTTP_REFERER" => "http://www.other-domain.com/other/path",
-        "HTTP_ACCEPT_CHARSET" => "utf-8, iso-8859-1;q=0.5",
-        "HTTP_ACCEPT_ENCODING" => "gzip, deflate",
-        "HTTP_ACCEPT_LANGUAGE" => "fr-FR,fr;q=0.8,en-US;q=0.6,en;q=0.4",
-        "HTTP_COOKIE" => "foo=bar; datadome=AHrlqAAAAAMA9RBP7xmrgZcAAAAAAA%3D%3D; baz=bar",
-        "GATEWAY_INTERFACE" => "CGI/1.2",
-        "SERVER_PORT" => "80",
-        "SERVER_PROTOCOL" => "HTTP/1.1",
-        "rack.url_scheme" => "http",
-        "SCRIPT_NAME" => "",
-        "REMOTE_ADDR" => "192.168.1.1",
-        "ORIGINAL_FULLPATH" => "/my/path?foo=bar&baz=1",
-        "ORIGINAL_SCRIPT_NAME" => "",
-      }
-    end
-
-    let(:exclude_matchers) { [] }
-    let(:include_matchers) { [] }
-
-    subject { described_class.new(env, exclude_matchers: exclude_matchers, include_matchers: include_matchers) }
-
     context "without matchers" do
       it "returns false" do
         expect(subject.ignore?).to eq(false)
@@ -168,6 +169,30 @@ RSpec.describe Datadome::Inquirer do
       it "returns true when the exclude matcher does not match and the include matcher does not match" do
         env["HTTP_HOST"] = "www.other-domain.com"
         expect(subject.ignore?).to eq(true)
+      end
+    end
+  end
+
+  describe "#intercept?" do
+    context "with monitoring mode disabled and when request is flagged as coming from a bot" do
+      let(:monitoring_mode) { true }
+
+      it "returns false" do
+        validation_response = instance_double("Datadome::ValidationResponse", pass: false, redirect: false)
+        subject.instance_variable_set('@validation_response', validation_response)
+
+        expect(subject.intercept?).to eq(false)
+      end
+    end
+
+    context "with monitoring mode enabled and when request is flagged as coming from a bot" do
+      let(:monitoring_mode) { true }
+
+      it "returns false" do
+        validation_response = instance_double("Datadome::ValidationResponse", pass: false, redirect: false)
+        subject.instance_variable_set('@validation_response', validation_response)
+
+        expect(subject.intercept?).to eq(false)
       end
     end
   end


### PR DESCRIPTION
Currently, when a request is flagged as coming from a bot, the gem intercepts the incoming request. This PR aims to allow the request to go through, even if flagged as coming from a bot, for monitoring purposes.