### PR TITLE
Add monitor mode and ability to expose enriched headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ Datadome.configure do |config|
 
   # Add exclude matchers (optional)
   config.exclude_matchers << ->(host, path) { path =~ /\.(jpg|jpeg|png|gif)/i }
+  
+  # Enable monitor mode (optional)
+  # Does not block incoming requests flagged as coming from a bot (useful for logging only)
+  config.monitor_mode = true
+  
+  # Expose enriched headers
+  # config.expose_headers = true
 end
 
 Datadome.logger = Logger.new(STDOUT, level: :debug)

--- a/lib/datadome/configuration.rb
+++ b/lib/datadome/configuration.rb
@@ -9,9 +9,11 @@ module Datadome
       @api_server = "api.datadome.co"
       @exclude_matchers = []
       @include_matchers = []
+      @monitor_mode = false
+      @expose_headers = false
     end
 
-    attr_accessor :api_key, :api_server, :exclude_matchers, :include_matchers
+    attr_accessor :api_key, :api_server, :exclude_matchers, :include_matchers, :monitor_mode, :expose_headers
 
   end
 end

--- a/lib/datadome/validation_response.rb
+++ b/lib/datadome/validation_response.rb
@@ -19,6 +19,8 @@ module Datadome
             pass
           end
 
+        validation_response.request_headers["X-DataDomeResponse"] = response.headers["X-DataDomeResponse"]
+
         parse_headers_list(response.headers["X-DataDome-request-headers"]).each do |key|
           validation_response.request_headers[key] = response.headers[key]
         end

--- a/spec/datadome/inquirer_spec.rb
+++ b/spec/datadome/inquirer_spec.rb
@@ -3,54 +3,56 @@
 require "spec_helper"
 
 RSpec.describe Datadome::Inquirer do
+  let(:env) do
+    {
+      "SERVER_SOFTWARE" => "thin 1.7.2 codename Bachmanity",
+      "SERVER_NAME" => "www.my-domain.com",
+      "rack.input" => StringIO.new("the body"),
+      "rack.version" => [1, 0],
+      # "rack.errors"=>#<IO:<STDERR>>,
+      "rack.multithread" => false,
+      "rack.multiprocess" => false,
+      "rack.run_once" => false,
+      "REQUEST_METHOD" => "GET",
+      "REQUEST_PATH" => "/my/path",
+      "PATH_INFO" => "/my/path",
+      "QUERY_STRING" => "foo=bar&baz=1",
+      "REQUEST_URI" => "/my/path?foo=bar&baz=1",
+      "HTTP_VERSION" => "HTTP/1.1",
+      "HTTP_HOST" => "www.my-domain.com",
+      "HTTP_CONNECTION" => "keep-alive",
+      "HTTP_PRAGMA" => "no-cache",
+      "HTTP_CACHE_CONTROL" => "no-cache, no-store, must-revalidate",
+      "HTTP_ACCEPT" => "*/*",
+      "HTTP_X_CSRF_TOKEN" => "p8NNwjcp0NBxO7hf5Y4jj10alFvIuE6qCHxGbz4tvNI3FHjZMutWhOJodqgneFKt9cSs1pRNq6Tbe7t1MqqYmA==",
+      "HTTP_USER_AGENT" => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36",
+      "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest",
+      "HTTP_X_FORWARDED_FOR" => "12.23.34.45",
+      "HTTP_ORIGIN" => "www.my-origin-domain.com",
+      "HTTP_REFERER" => "http://www.other-domain.com/other/path",
+      "HTTP_ACCEPT_CHARSET" => "utf-8, iso-8859-1;q=0.5",
+      "HTTP_ACCEPT_ENCODING" => "gzip, deflate",
+      "HTTP_ACCEPT_LANGUAGE" => "fr-FR,fr;q=0.8,en-US;q=0.6,en;q=0.4",
+      "HTTP_COOKIE" => "foo=bar; datadome=AHrlqAAAAAMA9RBP7xmrgZcAAAAAAA%3D%3D; baz=bar",
+      "GATEWAY_INTERFACE" => "CGI/1.2",
+      "SERVER_PORT" => "80",
+      "SERVER_PROTOCOL" => "HTTP/1.1",
+      "rack.url_scheme" => "http",
+      "SCRIPT_NAME" => "",
+      "REMOTE_ADDR" => "192.168.1.1",
+      "ORIGINAL_FULLPATH" => "/my/path?foo=bar&baz=1",
+      "ORIGINAL_SCRIPT_NAME" => "",
+    }
+  end
+
+  let(:exclude_matchers) { [] }
+  let(:include_matchers) { [] }
+  let(:monitor_mode) { false }
+  let(:expose_headers) { false }
+
+  subject { described_class.new(env, exclude_matchers: exclude_matchers, include_matchers: include_matchers, monitor_mode: monitor_mode, expose_headers: expose_headers) }
+
   describe "#ignore?" do
-    let(:env) do
-      {
-        "SERVER_SOFTWARE" => "thin 1.7.2 codename Bachmanity",
-        "SERVER_NAME" => "www.my-domain.com",
-        "rack.input" => StringIO.new("the body"),
-        "rack.version" => [1, 0],
-        # "rack.errors"=>#<IO:<STDERR>>,
-        "rack.multithread" => false,
-        "rack.multiprocess" => false,
-        "rack.run_once" => false,
-        "REQUEST_METHOD" => "GET",
-        "REQUEST_PATH" => "/my/path",
-        "PATH_INFO" => "/my/path",
-        "QUERY_STRING" => "foo=bar&baz=1",
-        "REQUEST_URI" => "/my/path?foo=bar&baz=1",
-        "HTTP_VERSION" => "HTTP/1.1",
-        "HTTP_HOST" => "www.my-domain.com",
-        "HTTP_CONNECTION" => "keep-alive",
-        "HTTP_PRAGMA" => "no-cache",
-        "HTTP_CACHE_CONTROL" => "no-cache, no-store, must-revalidate",
-        "HTTP_ACCEPT" => "*/*",
-        "HTTP_X_CSRF_TOKEN" => "p8NNwjcp0NBxO7hf5Y4jj10alFvIuE6qCHxGbz4tvNI3FHjZMutWhOJodqgneFKt9cSs1pRNq6Tbe7t1MqqYmA==",
-        "HTTP_USER_AGENT" => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36",
-        "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest",
-        "HTTP_X_FORWARDED_FOR" => "12.23.34.45",
-        "HTTP_ORIGIN" => "www.my-origin-domain.com",
-        "HTTP_REFERER" => "http://www.other-domain.com/other/path",
-        "HTTP_ACCEPT_CHARSET" => "utf-8, iso-8859-1;q=0.5",
-        "HTTP_ACCEPT_ENCODING" => "gzip, deflate",
-        "HTTP_ACCEPT_LANGUAGE" => "fr-FR,fr;q=0.8,en-US;q=0.6,en;q=0.4",
-        "HTTP_COOKIE" => "foo=bar; datadome=AHrlqAAAAAMA9RBP7xmrgZcAAAAAAA%3D%3D; baz=bar",
-        "GATEWAY_INTERFACE" => "CGI/1.2",
-        "SERVER_PORT" => "80",
-        "SERVER_PROTOCOL" => "HTTP/1.1",
-        "rack.url_scheme" => "http",
-        "SCRIPT_NAME" => "",
-        "REMOTE_ADDR" => "192.168.1.1",
-        "ORIGINAL_FULLPATH" => "/my/path?foo=bar&baz=1",
-        "ORIGINAL_SCRIPT_NAME" => "",
-      }
-    end
-
-    let(:exclude_matchers) { [] }
-    let(:include_matchers) { [] }
-
-    subject { described_class.new(env, exclude_matchers: exclude_matchers, include_matchers: include_matchers) }
-
     context "without matchers" do
       it "returns false" do
         expect(subject.ignore?).to eq(false)
@@ -168,6 +170,71 @@ RSpec.describe Datadome::Inquirer do
       it "returns true when the exclude matcher does not match and the include matcher does not match" do
         env["HTTP_HOST"] = "www.other-domain.com"
         expect(subject.ignore?).to eq(true)
+      end
+    end
+  end
+
+  describe "#intercept?" do
+    context "with monitor mode disabled and when request is flagged as coming from a bot" do
+      let(:monitor_mode) { true }
+
+      it "returns false" do
+        validation_response = instance_double("Datadome::ValidationResponse", pass: false, redirect: false)
+        subject.instance_variable_set('@validation_response', validation_response)
+
+        expect(subject.intercept?).to eq(false)
+      end
+    end
+
+    context "with monitor mode enabled and when request is flagged as coming from a bot" do
+      let(:monitor_mode) { true }
+
+      it "returns false" do
+        validation_response = instance_double("Datadome::ValidationResponse", pass: false, redirect: false)
+        subject.instance_variable_set('@validation_response', validation_response)
+
+        expect(subject.intercept?).to eq(false)
+      end
+    end
+  end
+
+  describe "#enriching" do
+      let(:response_headers) do
+        {
+          "X-DataDome"=>"protected",
+          "Set-Cookie"=>"datadome=QwHWxE4aQ8zM7e0O4IFsNEl3dbRYJdHvgxk4hqYQr-BJK3uUzi6CtLOiOvGywxu1KY_q8TrHyUJV_j_KppDbreHWdcMQL.GM2RfxP_vf4c; Max-Age=31536000; Domain=.trainline.eu; Path=/; Secure; SameSite=Lax",
+        }
+      end
+      let(:request_headers) do
+        {
+          "X-DataDomeResponse"=>"200"
+        }
+      end
+
+      before do
+        subject.instance_variable_set(
+          '@validation_response',
+          instance_double("Datadome::ValidationResponse", request_headers: request_headers, response_headers: response_headers),
+        )
+      end
+
+    context "with expose_headers option enabled" do
+      let(:expose_headers) { true }
+
+      it "adds enriched headers to the response headers" do
+        _status, headers, _response = subject.enriching { [200, {}, nil] }
+
+        expect(headers.keys).to include(*request_headers.keys, *response_headers.keys)
+      end
+    end
+
+    context "with expose_headers option disabled" do
+      let(:expose_headers) { false }
+
+      it "does not add enriched headers to the response headers" do
+        _status, headers, _response = subject.enriching { [200, {}, nil] }
+
+        expect(headers.keys).to include(*response_headers.keys)
       end
     end
   end


### PR DESCRIPTION
If we want the application server to be able to monitor and log datadome responses, it's useful to have options to not block bot requests, and also expose enriched headers.